### PR TITLE
Auto release

### DIFF
--- a/.github/workflows/auto-release-gui.yml
+++ b/.github/workflows/auto-release-gui.yml
@@ -1,0 +1,33 @@
+name: Auto Release GUI
+
+on:
+    push:
+        tags:
+            - 'gui-*'
+
+jobs:
+    build:
+        name: "Build windows"
+        runs-on: windows-latest
+        steps:
+            - name: "Checkout"
+              uses: actions/checkout@v4.2.1
+              with:
+                submodules: true
+            - name: "Install python requirements"
+              run: pip install -r requirements.txt
+            - name: "Build"
+              run: python setup.py
+            - name: "Zip dist"
+              uses: TheDoctor0/zip-release@0.7.6
+              with:
+                type: 'zip'
+                filename: 'release.zip'
+                path: 'dist'
+            - name: "Create release"
+              uses: softprops/action-gh-release@v2.0.8
+              with:
+                draft: true
+                files: |
+                    release.zip
+                    LICENSE

--- a/.github/workflows/auto-release-gui.yml
+++ b/.github/workflows/auto-release-gui.yml
@@ -23,11 +23,10 @@ jobs:
               with:
                 type: 'zip'
                 filename: 'release.zip'
-                path: 'dist'
+                directory: 'dist/'
             - name: "Create release"
               uses: softprops/action-gh-release@v2.0.8
               with:
                 draft: true
                 files: |
-                    release.zip
-                    LICENSE
+                    dist/release.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+cachetools==5.5.0
+pefile==2024.8.26
+py2exe==0.13.0.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from distutils.core import setup
 from py2exe import freeze
 
 freeze(windows=['main.py'], options={'bundle_files': 1})


### PR DESCRIPTION
Made a GitHub action that automatically creates a release for any commits with a gui-* tag.
This filter can be removed, but I assumed that only GUI updates are of interest for releases?

I couldn't get py2exe to generate proper one file distributions.
It always contained separate necessary DLL files.
Using [PyInstaller](https://pyinstaller.org/en/stable/) instead might be an option, as I know that can generate actual one file distributions.
For now I simply zip up the dist folder and upload that for the release.

Releases are currently set as drafts so a change log can be written before publishing it, but this can also be changed.

Closes #5 